### PR TITLE
CircleCI: Ignore out-of-date XCode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,8 @@ jobs:
           if [ -e .git/shallow ]; then echo git fetch --unshallow; fi
           git fetch origin --tags
           git reset --hard origin/master
+          sed -i '' 's/return if ENV\["TRAVIS"]/return if ENV["CI"]/' /usr/local/Homebrew/Library/Homebrew/extend/os/mac/diagnostic.rb
+          git -C /usr/local/Homebrew commit Library/Homebrew/extend/os/mac/diagnostic.rb -m 'Ignore out-of-date XCode on CircleCI'
           brew config
       - checkout
       - run: |


### PR DESCRIPTION
Fix the error:
```
Warning: Your Xcode (9.0) is outdated.
Please update to Xcode 9.0.1 (or delete it).
```